### PR TITLE
skip venv, .downloads and third_party with isort and pyink.

### DIFF
--- a/format.sh
+++ b/format.sh
@@ -18,5 +18,5 @@
 
 set -ex
 
-pyink --pyink-use-majority-quotes --pyink-indentation 2 ./
-isort --profile google --multi-line 7 --skip .downloads ./
+pyink --pyink-use-majority-quotes --pyink-indentation 2 --extend-exclude third_party --extend-exclude .downloads ./
+isort --profile google --multi-line 7 --skip .downloads ./ --skip venv --skip third_party


### PR DESCRIPTION
Manually tested that format.sh works as intended in my local setup.

format.sh now matches test_code_style.sh:
https://github.com/google-ai-edge/ai-edge-torch/blob/19a168c7f1776168248a861e733c88c1da7c9d06/ci/test_code_style.sh#L59-L67

BUG=fix dev workflow
