### PR TITLE
Do not run nightly workflows on forks.

### DIFF
--- a/.github/workflows/mark_stale.yml
+++ b/.github/workflows/mark_stale.yml
@@ -12,6 +12,9 @@ on:
 
 jobs:
   stale:
+    if: |
+      github.event_name == 'workflow_dispatch' ||
+      (github.event_name == 'schedule' && github.repository == 'google-ai-edge/ai-edge-torch') # don't run in forks.
 
     runs-on: ubuntu-latest
     permissions:

--- a/.github/workflows/nightly_generative_api.yml
+++ b/.github/workflows/nightly_generative_api.yml
@@ -12,6 +12,10 @@ on:
 
 jobs:
   run-generative-api-examples:
+    if: |
+      github.event_name == 'workflow_dispatch' ||
+      (github.event_name == 'schedule' && github.repository == 'google-ai-edge/ai-edge-torch') # don't run in forks.
+
     name: Generative API Examples
     uses: ./.github/workflows/generative_api_examples.yml
     with:

--- a/.github/workflows/nightly_model_coverage.yml
+++ b/.github/workflows/nightly_model_coverage.yml
@@ -12,6 +12,10 @@ on:
 
 jobs:
   run-model-coverage:
+    if: |
+      github.event_name == 'workflow_dispatch' ||
+      (github.event_name == 'schedule' && github.repository == 'google-ai-edge/ai-edge-torch') # don't run in forks.
+
     name: Model Coverage (nightly)
     uses: ./.github/workflows/model_coverage.yml
     secrets: inherit

--- a/.github/workflows/nightly_pip_test.yml
+++ b/.github/workflows/nightly_pip_test.yml
@@ -16,6 +16,10 @@ jobs:
       matrix:
         python-version: ["3.9", "3.10", "3.11"]
 
+    if: |
+      github.event_name == 'workflow_dispatch' ||
+      (github.event_name == 'schedule' && github.repository == 'google-ai-edge/ai-edge-torch') # don't run in forks.
+
     runs-on: ubuntu-latest
     steps:
       - uses: actions/setup-python@v4

--- a/.github/workflows/nightly_unittests.yml
+++ b/.github/workflows/nightly_unittests.yml
@@ -12,6 +12,10 @@ on:
 
 jobs:
   run-unittests-python:
+    if: |
+      github.event_name == 'workflow_dispatch' ||
+      (github.event_name == 'schedule' && github.repository == 'google-ai-edge/ai-edge-torch') # don't run in forks.
+
     name: Unit Tests Python
     uses: ./.github/workflows/unittests_python.yml
     with:


### PR DESCRIPTION
This change can't really be tested until:

 * it is merged: to make sure nothing breaks for the upstream repo
 * forks update to upstream/main: to confirm that workflows are not triggered in forks.

BUG=cleanup github workflows.
