### PR TITLE
remove trailing comment in workflow files

### DIFF
--- a/.github/workflows/mark_stale.yml
+++ b/.github/workflows/mark_stale.yml
@@ -14,7 +14,7 @@ jobs:
   stale:
     if: |
       github.event_name == 'workflow_dispatch' ||
-      (github.event_name == 'schedule' && github.repository == 'google-ai-edge/ai-edge-torch') # don't run in forks.
+      (github.event_name == 'schedule' && github.repository == 'google-ai-edge/ai-edge-torch')
 
     runs-on: ubuntu-latest
     permissions:

--- a/.github/workflows/nightly_generative_api.yml
+++ b/.github/workflows/nightly_generative_api.yml
@@ -14,7 +14,7 @@ jobs:
   run-generative-api-examples:
     if: |
       github.event_name == 'workflow_dispatch' ||
-      (github.event_name == 'schedule' && github.repository == 'google-ai-edge/ai-edge-torch') # don't run in forks.
+      (github.event_name == 'schedule' && github.repository == 'google-ai-edge/ai-edge-torch')
 
     name: Generative API Examples
     uses: ./.github/workflows/generative_api_examples.yml

--- a/.github/workflows/nightly_model_coverage.yml
+++ b/.github/workflows/nightly_model_coverage.yml
@@ -14,7 +14,7 @@ jobs:
   run-model-coverage:
     if: |
       github.event_name == 'workflow_dispatch' ||
-      (github.event_name == 'schedule' && github.repository == 'google-ai-edge/ai-edge-torch') # don't run in forks.
+      (github.event_name == 'schedule' && github.repository == 'google-ai-edge/ai-edge-torch')
 
     name: Model Coverage (nightly)
     uses: ./.github/workflows/model_coverage.yml

--- a/.github/workflows/nightly_pip_test.yml
+++ b/.github/workflows/nightly_pip_test.yml
@@ -18,7 +18,7 @@ jobs:
 
     if: |
       github.event_name == 'workflow_dispatch' ||
-      (github.event_name == 'schedule' && github.repository == 'google-ai-edge/ai-edge-torch') # don't run in forks.
+      (github.event_name == 'schedule' && github.repository == 'google-ai-edge/ai-edge-torch')
 
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/nightly_unittests.yml
+++ b/.github/workflows/nightly_unittests.yml
@@ -14,7 +14,7 @@ jobs:
   run-unittests-python:
     if: |
       github.event_name == 'workflow_dispatch' ||
-      (github.event_name == 'schedule' && github.repository == 'google-ai-edge/ai-edge-torch') # don't run in forks.
+      (github.event_name == 'schedule' && github.repository == 'google-ai-edge/ai-edge-torch')
 
     name: Unit Tests Python
     uses: ./.github/workflows/unittests_python.yml


### PR DESCRIPTION
https://github.com/google-ai-edge/ai-edge-torch/pull/15 was attempting to prevent nightly workflows from running in forks.

However, the yaml was incorrectly formatted, which gave the following error ([workflow_dispatch log](https://github.com/google-ai-edge/ai-edge-torch/actions/runs/9237935521)):
```
Invalid workflow file: .github/workflows/nightly_pip_test.yml#L19
The workflow is not valid. .github/workflows/nightly_pip_test.yml (Line: 19, Col: 9): Unexpected symbol: '#'. Located at position 134 within expression: github.event_name == 'workflow_dispatch' ||
(github.event_name == 'schedule' && github.repository == 'google-ai-edge/ai-edge-torch') # don't run in forks.
```

This PR is removing the trailing comment and has been verified to work by running the workflow via dispatch from my branch in my fork ([log](https://github.com/advaitjain/ai-edge-torch/actions/runs/9239015617)).

BUG=fix broken workflow.

![image](https://github.com/google-ai-edge/ai-edge-torch/assets/2789958/cffa6b7f-48c5-4b01-9bf6-c66f3cad7be8)
