### PR TITLE
Unpin tf-nightly in requirements.txt

### DIFF
--- a/.github/workflows/model_coverage.yml
+++ b/.github/workflows/model_coverage.yml
@@ -38,7 +38,9 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
 
-      - run: python -m pip install --upgrade pip setuptools
+      - run: |
+          python -m pip install --upgrade pip setuptools
+          python -m pip cache purge
 
       - name: Setup benchmark repository
         run: |

--- a/.github/workflows/model_coverage.yml
+++ b/.github/workflows/model_coverage.yml
@@ -37,8 +37,6 @@ jobs:
       - uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
-          cache: "pip"
-          cache-dependency-path: "**/*requirements.txt"
 
       - run: python -m pip install --upgrade pip setuptools
 

--- a/.github/workflows/unittests_python.yml
+++ b/.github/workflows/unittests_python.yml
@@ -31,7 +31,9 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
 
-      - run: python -m pip install --upgrade pip setuptools
+      - run: |
+          python -m pip install --upgrade pip setuptools
+          python -m pip cache purge
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/unittests_python.yml
+++ b/.github/workflows/unittests_python.yml
@@ -30,8 +30,6 @@ jobs:
       - uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
-          cache: "pip"
-          cache-dependency-path: "**/*requirements.txt"
 
       - run: python -m pip install --upgrade pip setuptools
 

--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ Nightly Release    | [![](https://github.com/google-ai-edge/ai-edge-torch/action
 
  * Python versions:  3.9, 3.10, 3.11
  * Operating system: Linux
- * PyTorch: ![torch](https://img.shields.io/badge/torch-2.4.0.dev20240602-blue)
+ * PyTorch: ![torch](https://img.shields.io/badge/torch-2.4.0.dev20240429-blue)
  * TensorFlow: [![tf-nightly](https://img.shields.io/badge/tf--nightly-latest-blue)](https://pypi.org/project/tf-nightly/)
 
 <!-- requirement badges are updated by ci/update_nightly_versions.py -->

--- a/README.md
+++ b/README.md
@@ -79,8 +79,8 @@ Nightly Release    | [![](https://github.com/google-ai-edge/ai-edge-torch/action
 
  * Python versions:  3.9, 3.10, 3.11
  * Operating system: Linux
- * PyTorch: ![torch](https://img.shields.io/badge/torch-2.4.0.dev20240429-blue)
- * TensorFlow: [![tf-nightly](https://img.shields.io/badge/tf--nightly-2.17.0.dev20240509-blue)](https://pypi.org/project/tf-nightly/)
+ * PyTorch: ![torch](https://img.shields.io/badge/torch-2.4.0.dev20240602-blue)
+ * TensorFlow: [![tf-nightly](https://img.shields.io/badge/tf--nightly-latest-blue)](https://pypi.org/project/tf-nightly/)
 
 <!-- requirement badges are updated by ci/update_nightly_versions.py -->
 

--- a/ci/update_nightly_versions.py
+++ b/ci/update_nightly_versions.py
@@ -84,7 +84,7 @@ def main():
 
   def sub(k, v, suffix=""):
     nonlocal requirements
-    pattern = f"{k}\s*(==|@)\s*[^\n;]+{suffix}"
+    pattern = f"{k}\s*(==|>=|@)\s*[^\n;]+{suffix}"
     assert re.findall(pattern, requirements, re.MULTILINE)
     requirements = re.sub(
         pattern,
@@ -120,11 +120,6 @@ def main():
   readme = re.sub(
       "badge/torch-[^-]+",
       f"badge/torch-{torch_version('torch', nightly_date_str)}",
-      readme,
-  )
-  readme = re.sub(
-      "badge/tf--nightly-[^-]+",
-      f"badge/tf--nightly-{tf_version(nightly_date_str)}",
       readme,
   )
   readme_file.write_text(readme)

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ numpy
 tabulate
 safetensors
 --pre
-tf-nightly==2.17.0.dev20240529
+tf-nightly>=2.17.0.dev20240529
 -f https://download.pytorch.org/whl/nightly/torch_nightly.html
 torch==2.4.0.dev20240429+cpu
 -f https://download.pytorch.org/whl/nightly/torch_nightly.html


### PR DESCRIPTION
ai-edge-torch-nightly will always pull in the latest tf-nightly. This will allow bug fixes and improvements to the TFLite Converter to be automatically available for ai-edge-torch without the need to manually bump up the tf-nightly version. (from @advaitjain)

This PR also disables pip cache in CIs (python unit tests and model coverage) to always collect latest tf-nightly. If regression happens due to tf-nightly, the failures would be captured in nightly readme badges and PR pre merge checks.

BUG=none