### PR TITLE
update tf-nightly version so that models w/ external cache can be converted.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ numpy
 tabulate
 safetensors
 --pre
-tf-nightly-cpu>=2.17.0.dev20240604
+tf-nightly-cpu>=2.17.0.dev20240606
 -f https://download.pytorch.org/whl/nightly/torch_nightly.html
 torch==2.4.0.dev20240429+cpu
 -f https://download.pytorch.org/whl/nightly/torch_nightly.html


### PR DESCRIPTION
The latest tf-nightly has a fix which allows to lower to dynamic update slice with int64 index.
BUG=none