### PR TITLE
Fix BuildInterpolateCompositePass with aten decompositions

### DIFF
--- a/ai_edge_torch/convert/fx_passes/build_interpolate_composite_pass.py
+++ b/ai_edge_torch/convert/fx_passes/build_interpolate_composite_pass.py
@@ -37,6 +37,7 @@ def _get_upsample_bilinear2d_pattern():
           x, scale_factor=2, mode="bilinear", align_corners=False
       ),
       export_args=(torch.rand(1, 3, 100, 100),),
+      decomp_table=_interpolate_decompositions,
   )
 
   @pattern.register_attr_builder
@@ -48,7 +49,6 @@ def _get_upsample_bilinear2d_pattern():
         "align_corners": False,
     }
 
-  pattern.run_decompositions(_interpolate_decompositions)
   return pattern
 
 
@@ -60,6 +60,7 @@ def _get_upsample_bilinear2d_align_corners_pattern():
           x, scale_factor=2, mode="bilinear", align_corners=True
       ),
       export_args=(torch.rand(1, 3, 100, 100),),
+      decomp_table=_interpolate_decompositions,
   )
 
   @pattern.register_attr_builder
@@ -71,7 +72,6 @@ def _get_upsample_bilinear2d_align_corners_pattern():
         "align_corners": True,
     }
 
-  pattern.run_decompositions(_interpolate_decompositions)
   return pattern
 
 
@@ -81,6 +81,7 @@ def _get_interpolate_nearest2d_pattern():
       "tfl.resize_nearest_neighbor",
       lambda x: torch.nn.functional.interpolate(x, scale_factor=2, mode="nearest"),
       export_args=(torch.rand(1, 3, 100, 100),),
+      decomp_table=_interpolate_decompositions,
   )
 
   @pattern.register_attr_builder
@@ -92,7 +93,6 @@ def _get_interpolate_nearest2d_pattern():
         "is_nchw_op": True,
     }
 
-  pattern.run_decompositions(_interpolate_decompositions)
   return pattern
 
 

--- a/ai_edge_torch/hlfb/mark_pattern/pattern.py
+++ b/ai_edge_torch/hlfb/mark_pattern/pattern.py
@@ -100,13 +100,18 @@ class ScalarAttrLocation:
 
 
 def _find_scalar_attr(
-    pattern_module: torch.nn.Module, export_args: tuple[Any], tracker: ScalarAttrTracker
+    pattern_module: torch.nn.Module,
+    export_args: tuple[Any],
+    tracker: ScalarAttrTracker,
+    decomp_table=None,
 ) -> ScalarAttrLocation:
   scalar_loc_intersections = None
   for source, target in tracker._source_targets:
     track_args = list(export_args)
     track_args[tracker.pattern_arg_pos] = source
     ep = torch.export.export(pattern_module, tuple(track_args))
+    if decomp_table is not None:
+      ep = ep.run_decompositions(decomp_table)
 
     scalar_locs = set()
     nodes = ep.graph_module.graph.nodes
@@ -145,6 +150,7 @@ class Pattern:
           ["Pattern", GraphModule, InternalMatch], Optional[dict[str, Any]]
       ] = None,
       scalar_attr_trackers: list[ScalarAttrTracker] = None,
+      decomp_table: Optional[dict[torch._ops.OperatorBase, Callable]] = None,
   ):
     """The PyTorch computation pattern to match against a model.
 
@@ -165,6 +171,8 @@ class Pattern:
         for scalar args in `export_args`, which are used to track
         the attr occurrence(s) and retrieve their values from the
         matched subgraph.
+      decomp_table (Optional[dict[torch._ops.OperatorBase, Callable]]):
+        The decomposition table to be run on the pattern's exported program.
     """
     if not isinstance(module, torch.nn.Module):
 
@@ -182,23 +190,25 @@ class Pattern:
     self.name = name
     self.attr_builder = attr_builder
     self._scalar_attr_trackers = scalar_attr_trackers if scalar_attr_trackers else []
-    self._set_exported_program(torch.export.export(module, export_args))
 
-  def _set_exported_program(self, exported_program: torch.export.ExportedProgram):
+    exported_program = torch.export.export(module, export_args)
+    if decomp_table is not None:
+      exported_program = exported_program.run_decompositions(decomp_table)
+
     self.exported_program = exported_program
     self.graph_module = self.exported_program.graph_module
+
+    self._scalar_attr_locations = []
+    for tracker in self._scalar_attr_trackers:
+      self._scalar_attr_locations.append(
+          _find_scalar_attr(module, export_args, tracker, decomp_table=decomp_table)
+      )
 
     # Sanitize graph_module for more precise pattern matching.
     # The graph_module to match against this pattern should apply equivalent
     # sanitization.
     self.graph_module = passes.remove_clone_ops(self.graph_module)
     self.graph_module = passes.remove_dangling_args(self.graph_module)
-
-    self._scalar_attr_locations = []
-    for tracker in self._scalar_attr_trackers:
-      self._scalar_attr_locations.append(
-          _find_scalar_attr(exported_program.module(), export_args, tracker)
-      )
 
     # Builds list of ordered input and output nodes.
     self.graph_nodes_map = {}
@@ -214,13 +224,6 @@ class Pattern:
         self.graph_nodes_map[spec.arg.name]
         for spec in self.exported_program.graph_signature.output_specs
     )
-
-  def run_decompositions(
-      self, decomp_table: Optional[dict[torch._ops.OperatorBase, Callable]] = None
-  ):
-    exported_program = self.exported_program.run_decompositions(decomp_table)
-    self._set_exported_program(exported_program)
-    return self
 
   def register_attr_builder(self, attr_builder):
     self.attr_builder = attr_builder

--- a/ai_edge_torch/hlfb/mark_pattern/pattern.py
+++ b/ai_edge_torch/hlfb/mark_pattern/pattern.py
@@ -197,7 +197,7 @@ class Pattern:
     self._scalar_attr_locations = []
     for tracker in self._scalar_attr_trackers:
       self._scalar_attr_locations.append(
-          _find_scalar_attr(module, export_args, tracker)
+          _find_scalar_attr(exported_program.module(), export_args, tracker)
       )
 
     # Builds list of ordered input and output nodes.


### PR DESCRIPTION
The issue does not break the current 0429 nightly dependencies. This is a fix for forward compatibility and future dependencies upgrade.

Starting from torch 2.5.0 nightly (after mid June 2024), `torch.nn.functional.interpolate` no longer gets decomposed right after export but exported to `torch.ops.aten.upsample_nearest2d.vec` and `torch.ops.aten.upsample_bilinear2d.vec` in the first step. This behavior breaks all our pattern matching composite builder.

The fix in this PR runs decompositions on patterns and exported model for these ops. A more stable future work would be relying on aten composite builder, instead of decomposing then pattern matching.

BUG=https://b.corp.google.com/issues/348413649

