### PR TITLE
Relax torch version requirement

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -74,6 +74,6 @@ setup(
         "scipy",
         "safetensors",
         "tabulate",
-        "torch==2.4.*",  # 2.4.0 stable release does not exist. Force using torch nightly.
+        "torch>=2.4.0",  # 2.4.0 stable release does not exist. Force using torch nightly.
     ],
 )


### PR DESCRIPTION
Change torch version requirement to `torch>=2.4.0` to work with future 2.4.0 torch stable release and 2.5.0 nightly releases.

BUG=https://b.corp.google.com/issues/348401909