### PR TITLE
Support kwargs in ai_edge_torch.convert to named inputs

### DIFF
--- a/ai_edge_torch/convert/conversion.py
+++ b/ai_edge_torch/convert/conversion.py
@@ -88,16 +88,14 @@ def convert_signatures(
   _warn_training_modules(signatures)
 
   exported_programs: torch.export.ExportedProgram = [
-      torch.export.export(
-          sig.module, sig.sample_args, dynamic_shapes=sig.dynamic_shapes
-      )
+      torch.export.export(sig.module, sig.flat_args, dynamic_shapes=sig.dynamic_shapes)
       for sig in signatures
   ]
 
   # Apply default fx passes
   exported_programs = list(map(_run_convert_passes, exported_programs))
   shlo_bundles: list[stablehlo.StableHLOModelBundle] = [
-      cutils.exported_program_to_stablehlo_bundle(exported, sig.sample_args)
+      cutils.exported_program_to_stablehlo_bundle(exported, sig.flat_args)
       for exported, sig in zip(exported_programs, signatures)
   ]
 

--- a/ai_edge_torch/convert/conversion_utils.py
+++ b/ai_edge_torch/convert/conversion_utils.py
@@ -92,7 +92,7 @@ class Signature:
       else:
         # value_spec.num_leaves may be greater than 1 when the value is a (nested)
         # tuple of tensors. We haven't decided how we should support flattenable
-        # tensor containers  as inputs.
+        # tensor containers as inputs.
         # TODO(b/352584188): Decide the behavior of tensor container as input (flatten or reject)
         for i in range(value_spec.num_leaves):
           names.append(f"{name}_{i}")

--- a/ai_edge_torch/convert/conversion_utils.py
+++ b/ai_edge_torch/convert/conversion_utils.py
@@ -79,8 +79,15 @@ class Signature:
       names.append(f"args_{i}")
 
     for name, value_spec in zip(kwargs_spec.context, kwargs_spec.children_specs):
-      for i in range(value_spec.num_leaves):
-        names.append(f"{name}_{i}")
+      if value_spec.num_leaves == 1:
+        names.append(name)
+      else:
+        # value_spec.num_leaves may be greater than 1 when the value is a (nested)
+        # tuple of tensors. We haven't decided how we should support flattenable
+        # tensor containers  as inputs.
+        # TODO: Decide the behavior of tensor container as input (flatten or reject)
+        for i in range(value_spec.num_leaves):
+          names.append(f"{name}_{i}")
     return names
 
   @property

--- a/ai_edge_torch/convert/conversion_utils.py
+++ b/ai_edge_torch/convert/conversion_utils.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 # ==============================================================================
 
+import collections
 import copy
 from dataclasses import dataclass
 import gc
@@ -78,7 +79,14 @@ class Signature:
     for i in range(args_spec.num_leaves):
       names.append(f"args_{i}")
 
-    for name, value_spec in zip(kwargs_spec.context, kwargs_spec.children_specs):
+    dict_context = (
+        kwargs_spec.context
+        if kwargs_spec.type is not collections.defaultdict
+        # ignore mismatch of `default_factory` for defaultdict
+        else kwargs_spec.context[1]
+    )
+
+    for name, value_spec in zip(dict_context, kwargs_spec.children_specs):
       if value_spec.num_leaves == 1:
         names.append(name)
       else:

--- a/ai_edge_torch/convert/conversion_utils.py
+++ b/ai_edge_torch/convert/conversion_utils.py
@@ -57,13 +57,13 @@ class Signature:
     args, kwargs = self.sample_args, self.sample_kwargs
     if args is not None:
       if not isinstance(args, tuple):
-        # TODO: Check value types
+        # TODO(b/352584188): Check value types
         raise ValueError("sample_args must be a tuple of torch tensors.")
     if kwargs is not None:
       if not isinstance(kwargs, dict) or not all(
           isinstance(key, str) for key in kwargs.keys()
       ):
-        # TODO: Check value types
+        # TODO(b/352584188): Check value types
         raise ValueError("sample_kwargs must be a dict of string to tensor.")
 
     args = args if args is not None else tuple()
@@ -93,7 +93,7 @@ class Signature:
         # value_spec.num_leaves may be greater than 1 when the value is a (nested)
         # tuple of tensors. We haven't decided how we should support flattenable
         # tensor containers  as inputs.
-        # TODO: Decide the behavior of tensor container as input (flatten or reject)
+        # TODO(b/352584188): Decide the behavior of tensor container as input (flatten or reject)
         for i in range(value_spec.num_leaves):
           names.append(f"{name}_{i}")
     return names

--- a/ai_edge_torch/convert/test/test_convert.py
+++ b/ai_edge_torch/convert/test/test_convert.py
@@ -296,7 +296,7 @@ class TestConvert(unittest.TestCase):
       def forward(self, x, y):
         return x + y
 
-    args_gen = lambda: torch.randn(10, 10)
+    args_gen = lambda: (torch.randn(10, 10),)
     kwargs_gen = lambda: dict(y=torch.randn(10, 10))
 
     model = SampleModel().eval()

--- a/ai_edge_torch/convert/test/test_convert.py
+++ b/ai_edge_torch/convert/test/test_convert.py
@@ -267,6 +267,45 @@ class TestConvert(unittest.TestCase):
           model_coverage.compare_tflite_torch(edge_model, model, validate_input)
       )
 
+  def test_convert_model_with_kwargs(self):
+    """
+    Test converting a simple model with sample_kwargs.
+    """
+
+    class SampleModel(torch.nn.Module):
+
+      def forward(self, x, y):
+        return x + y
+
+    kwargs_gen = lambda: dict(x=torch.randn(10, 10), y=torch.randn(10, 10))
+
+    model = SampleModel().eval()
+    edge_model = ai_edge_torch.convert(model, sample_kwargs=kwargs_gen())
+
+    self.assertTrue(
+        model_coverage.compare_tflite_torch(edge_model, model, kwargs=kwargs_gen)
+    )
+
+  def test_convert_model_with_args_kwargs(self):
+    """
+    Test converting a simple model with both sample_args and sample_kwargs.
+    """
+
+    class SampleModel(torch.nn.Module):
+
+      def forward(self, x, y):
+        return x + y
+
+    args_gen = lambda: torch.randn(10, 10)
+    kwargs_gen = lambda: dict(y=torch.randn(10, 10))
+
+    model = SampleModel().eval()
+    edge_model = ai_edge_torch.convert(model, args_gen(), kwargs_gen())
+
+    self.assertTrue(
+        model_coverage.compare_tflite_torch(edge_model, model, args_gen, kwargs_gen)
+    )
+
 
 if __name__ == "__main__":
   unittest.main()


### PR DESCRIPTION
torch_xla does not support exported_program with kwargs to stablehlo, so I need to flatten inputs to a tuple before the very first torch.export.export.

BUG=https://b.corp.google.com/issues/350510246