### PR TITLE
Allow explictly setting head_dim instead of deducing it.

### DIFF
--- a/ai_edge_torch/generative/examples/gemma/gemma.py
+++ b/ai_edge_torch/generative/examples/gemma/gemma.py
@@ -69,7 +69,7 @@ class Gemma(nn.Module):
     )
     self.rope_cache = attn_utils.build_rope_cache(
         size=config.kv_cache_max,
-        dim=int(config.attn_config.rotary_percentage * config.head_dim),
+        dim=int(config.attn_config.rotary_percentage * config.attn_config.head_dim),
         base=10_000,
         condense_ratio=1,
         dtype=torch.float32,
@@ -111,6 +111,7 @@ class Gemma(nn.Module):
 def get_model_config_2b(kv_cache_max_len: int = 1024) -> cfg.ModelConfig:
   attn_config = cfg.AttentionConfig(
       num_heads=8,
+      head_dim=256,
       num_query_groups=1,
       rotary_percentage=1.0,
   )

--- a/ai_edge_torch/generative/examples/phi2/phi2.py
+++ b/ai_edge_torch/generative/examples/phi2/phi2.py
@@ -64,7 +64,7 @@ class Phi2(nn.Module):
     )
     self.rope_cache = attn_utils.build_rope_cache(
         size=config.kv_cache_max,
-        dim=int(config.attn_config.rotary_percentage * config.head_dim),
+        dim=int(config.attn_config.rotary_percentage * config.attn_config.head_dim),
         base=10_000,
         condense_ratio=1,
         dtype=torch.float32,
@@ -105,6 +105,7 @@ class Phi2(nn.Module):
 def get_model_config(kv_cache_max_len: int = 1024) -> cfg.ModelConfig:
   attn_config = cfg.AttentionConfig(
       num_heads=32,
+      head_dim=80,
       num_query_groups=32,
       rotary_percentage=0.4,
       qkv_use_bias=True,

--- a/ai_edge_torch/generative/examples/stable_diffusion/clip.py
+++ b/ai_edge_torch/generative/examples/stable_diffusion/clip.py
@@ -81,6 +81,7 @@ def get_model_config() -> cfg.ModelConfig:
 
   attn_config = cfg.AttentionConfig(
       num_heads=num_heads,
+      head_dim=embedding_dim // num_heads,
       num_query_groups=num_query_groups,
       rotary_percentage=0.0,
       qkv_use_bias=True,

--- a/ai_edge_torch/generative/examples/stable_diffusion/decoder.py
+++ b/ai_edge_torch/generative/examples/stable_diffusion/decoder.py
@@ -285,6 +285,7 @@ def get_model_config() -> unet_cfg.AutoEncoderConfig:
       normalization_config=norm_config,
       attention_config=layers_cfg.AttentionConfig(
           num_heads=1,
+          head_dim=block_out_channels[-1],
           num_query_groups=1,
           qkv_use_bias=True,
           output_proj_use_bias=True,

--- a/ai_edge_torch/generative/examples/stable_diffusion/diffusion.py
+++ b/ai_edge_torch/generative/examples/stable_diffusion/diffusion.py
@@ -250,6 +250,7 @@ class Diffusion(nn.Module):
 
     attention_config = layers_cfg.AttentionConfig(
         num_heads=config.transformer_num_attention_heads,
+        head_dim=block_out_channels[0] // config.transformer_num_attention_heads,
         num_query_groups=config.transformer_num_attention_heads,
         rotary_percentage=0.0,
         qkv_transpose_before_split=True,

--- a/ai_edge_torch/generative/examples/t5/t5_attention.py
+++ b/ai_edge_torch/generative/examples/t5/t5_attention.py
@@ -183,7 +183,9 @@ class T5Attention(CrossAttention):
     x = self.pre_atten_norm(x)
     B, T, C = x.size()  # batch size, sequence length, embedding dimensionality (n_embd)
     query_states = self.q_projection(x)
-    query_states = query_states.reshape(B, T, -1, self.head_dim)  # (B, T, nh_q, hs)
+    query_states = query_states.reshape(
+        B, T, -1, self.config.head_dim
+    )  # (B, T, nh_q, hs)
 
     if key_value_states is not None:
       (
@@ -195,13 +197,13 @@ class T5Attention(CrossAttention):
       )  # batch size, sequence length, embedding dimensionality (n_embd)
       key_states = self.k_projection(key_value_states)
       value_states = self.v_projection(key_value_states)
-      key_states = key_states.reshape(kvB, kvT, -1, self.head_dim)
-      value_states = value_states.reshape(kvB, kvT, -1, self.head_dim)
+      key_states = key_states.reshape(kvB, kvT, -1, self.config.head_dim)
+      value_states = value_states.reshape(kvB, kvT, -1, self.config.head_dim)
     else:
       key_states = self.k_projection(x)
       value_states = self.v_projection(x)
-      key_states = key_states.reshape(B, T, -1, self.head_dim)
-      value_states = value_states.reshape(B, T, -1, self.head_dim)
+      key_states = key_states.reshape(B, T, -1, self.config.head_dim)
+      value_states = value_states.reshape(B, T, -1, self.config.head_dim)
 
     if key_value_states is None and self.kv_cache is not None:
       key_states, value_states = self.kv_cache.update_cache(
@@ -218,12 +220,17 @@ class T5Attention(CrossAttention):
             0
         )  # shape (1, num_heads, query_length, key_length)
       else:
-        # position_bias = torch.zeros(B, self.n_heads, T, self.head_dim, dtype=torch.float32)
+        # position_bias = torch.zeros(B, self.n_heads, T, self.config.head_dim, dtype=torch.float32)
         position_bias = torch.zeros_like(mask, dtype=torch.float32)
 
     mask = mask + position_bias
     y = self.sdpa_func(
-        query_states, key_states, value_states, self.head_dim, mask=mask, scale=1.0
+        query_states,
+        key_states,
+        value_states,
+        self.config.head_dim,
+        mask=mask,
+        scale=1.0,
     )
     y = y.reshape(B, T, C)  # re-assemble all head outputs side by side
     # output projection

--- a/ai_edge_torch/generative/examples/test_models/toy_model.py
+++ b/ai_edge_torch/generative/examples/test_models/toy_model.py
@@ -44,7 +44,7 @@ class ToySingleLayerModel(torch.nn.Module):
     )
     self.rope_cache = attn_utils.build_rope_cache(
         size=config.max_seq_len,
-        dim=int(config.attn_config.rotary_percentage * config.head_dim),
+        dim=int(config.attn_config.rotary_percentage * config.attn_config.head_dim),
         base=10_000,
         condense_ratio=1,
         dtype=torch.float32,
@@ -72,7 +72,11 @@ class ToySingleLayerModel(torch.nn.Module):
 
 def get_model_config() -> cfg.ModelConfig:
   attn_config = cfg.AttentionConfig(
-      num_heads=32, num_query_groups=4, rotary_percentage=1.0, enable_kv_cache=False
+      num_heads=32,
+      head_dim=4,
+      num_query_groups=4,
+      rotary_percentage=1.0,
+      enable_kv_cache=False,
   )
   ff_config = cfg.FeedForwardConfig(
       type=cfg.FeedForwardType.GATED,

--- a/ai_edge_torch/generative/examples/test_models/toy_model_with_external_kv_cache.py
+++ b/ai_edge_torch/generative/examples/test_models/toy_model_with_external_kv_cache.py
@@ -47,7 +47,7 @@ class ToyModelWithExternalKV(torch.nn.Module):
     )
     self.rope_cache = attn_utils.build_rope_cache(
         size=config.max_seq_len,
-        dim=int(config.attn_config.rotary_percentage * config.head_dim),
+        dim=int(config.attn_config.rotary_percentage * config.attn_config.head_dim),
         base=10_000,
         condense_ratio=1,
         dtype=torch.float32,
@@ -91,7 +91,7 @@ def _export_stablehlo_mlir(model, args):
 
 def get_model_config() -> cfg.ModelConfig:
   attn_config = cfg.AttentionConfig(
-      num_heads=32, num_query_groups=4, rotary_percentage=1.0
+      num_heads=32, head_dim=4, num_query_groups=4, rotary_percentage=1.0
   )
   ff_config = cfg.FeedForwardConfig(
       type=cfg.FeedForwardType.GATED,

--- a/ai_edge_torch/generative/examples/test_models/toy_model_with_kv_cache.py
+++ b/ai_edge_torch/generative/examples/test_models/toy_model_with_kv_cache.py
@@ -46,7 +46,7 @@ class ToyModelWithKV(torch.nn.Module):
     )
     self.rope_cache = attn_utils.build_rope_cache(
         size=config.max_seq_len,
-        dim=int(config.attn_config.rotary_percentage * config.head_dim),
+        dim=int(config.attn_config.rotary_percentage * config.attn_config.head_dim),
         base=10_000,
         condense_ratio=1,
         dtype=torch.float32,
@@ -79,7 +79,7 @@ def _export_stablehlo_mlir(model, args):
 
 def get_model_config() -> cfg.ModelConfig:
   attn_config = cfg.AttentionConfig(
-      num_heads=32, num_query_groups=4, rotary_percentage=1.0
+      num_heads=32, head_dim=4, num_query_groups=4, rotary_percentage=1.0
   )
   ff_config = cfg.FeedForwardConfig(
       type=cfg.FeedForwardType.GATED,

--- a/ai_edge_torch/generative/examples/tiny_llama/tiny_llama.py
+++ b/ai_edge_torch/generative/examples/tiny_llama/tiny_llama.py
@@ -65,7 +65,7 @@ class TinyLLamma(nn.Module):
     )
     self.rope_cache = attn_utils.build_rope_cache(
         size=config.kv_cache_max,
-        dim=int(config.attn_config.rotary_percentage * config.head_dim),
+        dim=int(config.attn_config.rotary_percentage * config.attn_config.head_dim),
         base=10_000,
         condense_ratio=1,
         dtype=torch.float32,
@@ -107,6 +107,7 @@ class TinyLLamma(nn.Module):
 def get_model_config(kv_cache_max_len: int = 1024) -> cfg.ModelConfig:
   attn_config = cfg.AttentionConfig(
       num_heads=32,
+      head_dim=64,
       num_query_groups=4,
       rotary_percentage=1.0,
   )

--- a/ai_edge_torch/generative/fx_passes/test/test_remove_sdpa_zero_mask_pass.py
+++ b/ai_edge_torch/generative/fx_passes/test/test_remove_sdpa_zero_mask_pass.py
@@ -100,6 +100,7 @@ class TestRemoveSDPAZeroMaskPass(unittest.TestCase):
           normalization_config=norm_config,
           attention_config=layers_cfg.AttentionConfig(
               num_heads=1,
+              head_dim=block_out_channels[-1],
               num_query_groups=1,
               qkv_use_bias=True,
               output_proj_use_bias=True,

--- a/ai_edge_torch/generative/layers/attention.py
+++ b/ai_edge_torch/generative/layers/attention.py
@@ -136,14 +136,16 @@ class CausalSelfAttention(nn.Module):
       enable_hlfb (bool): whether hlfb is enabled or not.
     """
     super().__init__()
-    self.head_dim = dim // config.num_heads
-    shape = (config.num_heads + 2 * config.num_query_groups) * self.head_dim
-    # Key, query, value projections for all heads.
-    self.qkv_projection = nn.Linear(dim, shape, bias=config.qkv_use_bias)
-    self.output_projection = nn.Linear(dim, dim, bias=config.output_proj_use_bias)
     self.config = config
     self.kv_cache = None
     self.batch_size = batch_size
+    qkv_shape = (config.num_heads + 2 * config.num_query_groups) * config.head_dim
+    output_shape = config.num_heads * config.head_dim
+    # Key, query, value projections for all heads.
+    self.qkv_projection = nn.Linear(dim, qkv_shape, bias=config.qkv_use_bias)
+    self.output_projection = nn.Linear(
+        output_shape, dim, bias=config.output_proj_use_bias
+    )
 
     # Build a k/v cache with size (batch_size, kv_cache_max, n_heads, head_dim).
     if config.enable_kv_cache:
@@ -151,7 +153,7 @@ class CausalSelfAttention(nn.Module):
           batch_size,
           kv_cache_max,
           config.num_query_groups,
-          self.head_dim,
+          config.head_dim,
           enable_hlfb,
       )
 
@@ -180,7 +182,7 @@ class CausalSelfAttention(nn.Module):
       output activation from this self attention layer.
     """
     # Batch size, sequence length, embedding dimensionality.
-    B, T, E = x.size()
+    B, T, _ = x.size()
     assert (
         B == self.batch_size
     ), "batch size of input tensor must match with the batch size specified in the model configuration."
@@ -191,7 +193,7 @@ class CausalSelfAttention(nn.Module):
     q_per_kv = self.config.num_heads // self.config.num_query_groups
     # Each group has >=1 queries, 1 key, and 1 value.
     if self.config.qkv_transpose_before_split:
-      qkv = qkv.view(B, T, -1, self.head_dim)
+      qkv = qkv.view(B, T, -1, self.config.head_dim)
       q, k, v = qkv.split(
           (
               q_per_kv * self.config.num_query_groups,
@@ -203,23 +205,24 @@ class CausalSelfAttention(nn.Module):
     else:
       qkv = qkv.view(B, T, self.config.num_query_groups, -1)
       q, k, v = qkv.split(
-          (q_per_kv * self.head_dim, self.head_dim, self.head_dim), dim=-1
+          (q_per_kv * self.config.head_dim, self.config.head_dim, self.config.head_dim),
+          dim=-1,
       )
 
-    q = q.reshape(B, T, -1, self.head_dim)
-    k = k.reshape(B, T, -1, self.head_dim)
-    v = v.reshape(B, T, -1, self.head_dim)
+    q = q.reshape(B, T, -1, self.config.head_dim)
+    k = k.reshape(B, T, -1, self.config.head_dim)
+    v = v.reshape(B, T, -1, self.config.head_dim)
 
     # Compute rotary positional embedding for query and key.
-    n_elem = int(self.config.rotary_percentage * self.head_dim)
+    n_elem = int(self.config.rotary_percentage * self.config.head_dim)
     q, k = _embed_rope(q, k, n_elem, rope)
 
     if self.kv_cache is not None:
       # TODO(haoliang): Handle when execeeding max sequence length.
       k, v = self.kv_cache.update_cache(input_pos, k, v)
 
-    y = self.sdpa_func(q, k, v, self.head_dim, mask=mask)
-    y = y.reshape(B, T, E)
+    y = self.sdpa_func(q, k, v, self.config.head_dim, mask=mask)
+    y = y.reshape(B, T, _)
 
     # Compute the output projection.
     y = self.output_projection(y)

--- a/ai_edge_torch/generative/layers/model_config.py
+++ b/ai_edge_torch/generative/layers/model_config.py
@@ -55,7 +55,7 @@ class FeedForwardType(enum.Enum):
 
 @dataclass
 class AttentionConfig:
-  """Attention model's parameters."""
+  """Attention module's parameters."""
 
   num_heads: int
   head_dim: int

--- a/ai_edge_torch/generative/layers/model_config.py
+++ b/ai_edge_torch/generative/layers/model_config.py
@@ -55,9 +55,10 @@ class FeedForwardType(enum.Enum):
 
 @dataclass
 class AttentionConfig:
-  """Attention moduel's parameters."""
+  """Attention model's parameters."""
 
   num_heads: int
+  head_dim: int
   # Used to determine number of groups in grouped query attention (GQA)
   # https://arxiv.org/pdf/2305.13245.pdf
   num_query_groups: Optional[int]
@@ -152,7 +153,3 @@ class ModelConfig:
       return self.kv_cache_max_len
     else:
       return self.max_seq_len
-
-  @property
-  def head_dim(self) -> int:
-    return self.embedding_dim // self.attn_config.num_heads

--- a/ai_edge_torch/generative/utilities/loader.py
+++ b/ai_edge_torch/generative/utilities/loader.py
@@ -319,9 +319,9 @@ class ModelLoader:
   ) -> torch.Tensor:
     if config.attn_config.qkv_fused_interleaved:
       q_per_kv = config.attn_config.num_heads // config.attn_config.num_query_groups
-      qs = torch.split(q, config.head_dim * q_per_kv)
-      ks = torch.split(k, config.head_dim)
-      vs = torch.split(v, config.head_dim)
+      qs = torch.split(q, config.attn_config.head_dim * q_per_kv)
+      ks = torch.split(k, config.attn_config.head_dim)
+      vs = torch.split(v, config.attn_config.head_dim)
       cycled = [t for group in zip(qs, ks, vs) for t in group]
       return torch.cat(cycled)
     else:

--- a/ai_edge_torch/generative/utilities/stable_diffusion_loader.py
+++ b/ai_edge_torch/generative/utilities/stable_diffusion_loader.py
@@ -698,6 +698,7 @@ class DiffusionModelLoader(BaseLoader):
 
     attention_config = layers_config.AttentionConfig(
         num_heads=config.transformer_num_attention_heads,
+        head_dim=config.block_out_channels[0] // config.transformer_num_attention_heads,
         num_query_groups=config.transformer_num_attention_heads,
         rotary_percentage=0.0,
         qkv_transpose_before_split=True,

--- a/ai_edge_torch/generative/utilities/t5_loader.py
+++ b/ai_edge_torch/generative/utilities/t5_loader.py
@@ -476,8 +476,8 @@ class ModelLoader:
       v: torch.Tensor,
   ) -> torch.Tensor:
     q_per_kv = config.attn_config.num_heads // config.attn_config.num_query_groups
-    qs = torch.split(q, config.head_dim * q_per_kv)
-    ks = torch.split(k, config.head_dim)
-    vs = torch.split(v, config.head_dim)
+    qs = torch.split(q, config.attn_config.head_dim * q_per_kv)
+    ks = torch.split(k, config.attn_config.head_dim)
+    vs = torch.split(v, config.attn_config.head_dim)
     cycled = [t for group in zip(qs, ks, vs) for t in group]
     return torch.cat(cycled)


### PR DESCRIPTION
This is a requirement for the upcoming OpenELM models.

Note that head_dim is also moved down to the attention config: this parameter is related to attention so it has no reason to live under the main model config. 

Please review carefully to make sure I'm not breaking anything here :)

BUG=https://b.corp.google.com/issues/352478939

