### PR TITLE
Explicit head_dim configuration

### DIFF
--- a/ai_edge_torch/generative/examples/experimental/gemma/gemma.py
+++ b/ai_edge_torch/generative/examples/experimental/gemma/gemma.py
@@ -125,6 +125,7 @@ class Gemma(nn.Module):
 def get_model_config_2b(kv_cache_max_len: int = 1024) -> cfg.ModelConfig:
   attn_config = cfg.AttentionConfig(
       num_heads=8,
+      head_dim=256,
       num_query_groups=1,
       rotary_percentage=1.0,
   )

--- a/ai_edge_torch/generative/examples/experimental/gemma/gemma.py
+++ b/ai_edge_torch/generative/examples/experimental/gemma/gemma.py
@@ -73,7 +73,9 @@ class Gemma(nn.Module):
     )
     self.rope_cache = attn_utils.build_rope_cache(
         size=config.kv_cache_max,
-        dim=int(config.attn_config.rotary_percentage * config.head_dim),
+        dim=int(
+            config.attn_config.rotary_percentage * config.attn_config.head_dim
+        ),
         base=10_000,
         condense_ratio=1,
         dtype=torch.float32,

--- a/ai_edge_torch/generative/examples/experimental/phi/phi2.py
+++ b/ai_edge_torch/generative/examples/experimental/phi/phi2.py
@@ -68,7 +68,9 @@ class Phi2(nn.Module):
     )
     self.rope_cache = attn_utils.build_rope_cache(
         size=config.kv_cache_max,
-        dim=int(config.attn_config.rotary_percentage * config.head_dim),
+        dim=int(
+            config.attn_config.rotary_percentage * config.attn_config.head_dim
+        ),
         base=10_000,
         condense_ratio=1,
         dtype=torch.float32,
@@ -118,6 +120,7 @@ class Phi2(nn.Module):
 def get_model_config(kv_cache_max_len: int = 1024) -> cfg.ModelConfig:
   attn_config = cfg.AttentionConfig(
       num_heads=32,
+      head_dim=80,
       num_query_groups=32,
       rotary_percentage=0.4,
       qkv_use_bias=True,

--- a/ai_edge_torch/generative/examples/experimental/tiny_llama/tiny_llama.py
+++ b/ai_edge_torch/generative/examples/experimental/tiny_llama/tiny_llama.py
@@ -70,7 +70,9 @@ class TinyLLamma(nn.Module):
     )
     self.rope_cache = attn_utils.build_rope_cache(
         size=config.kv_cache_max,
-        dim=int(config.attn_config.rotary_percentage * config.head_dim),
+        dim=int(
+            config.attn_config.rotary_percentage * config.attn_config.head_dim
+        ),
         base=10_000,
         condense_ratio=1,
         dtype=torch.float32,
@@ -121,6 +123,7 @@ class TinyLLamma(nn.Module):
 def get_model_config(kv_cache_max_len: int = 1024) -> cfg.ModelConfig:
   attn_config = cfg.AttentionConfig(
       num_heads=32,
+      head_dim=64,
       num_query_groups=4,
       rotary_percentage=1.0,
   )

--- a/ai_edge_torch/generative/examples/gemma/gemma.py
+++ b/ai_edge_torch/generative/examples/gemma/gemma.py
@@ -68,7 +68,9 @@ class Gemma(nn.Module):
     )
     self.rope_cache = attn_utils.build_rope_cache(
         size=config.kv_cache_max,
-        dim=int(config.attn_config.rotary_percentage * config.attn_config.head_dim),
+        dim=int(
+            config.attn_config.rotary_percentage * config.attn_config.head_dim
+        ),
         base=10_000,
         condense_ratio=1,
         dtype=torch.float32,

--- a/ai_edge_torch/generative/examples/gemma/gemma.py
+++ b/ai_edge_torch/generative/examples/gemma/gemma.py
@@ -68,7 +68,7 @@ class Gemma(nn.Module):
     )
     self.rope_cache = attn_utils.build_rope_cache(
         size=config.kv_cache_max,
-        dim=int(config.attn_config.rotary_percentage * config.head_dim),
+        dim=int(config.attn_config.rotary_percentage * config.attn_config.head_dim),
         base=10_000,
         condense_ratio=1,
         dtype=torch.float32,
@@ -113,6 +113,7 @@ class Gemma(nn.Module):
 def get_model_config_2b(kv_cache_max_len: int = 1024) -> cfg.ModelConfig:
   attn_config = cfg.AttentionConfig(
       num_heads=8,
+      head_dim=256,
       num_query_groups=1,
       rotary_percentage=1.0,
   )

--- a/ai_edge_torch/generative/examples/phi2/phi2.py
+++ b/ai_edge_torch/generative/examples/phi2/phi2.py
@@ -63,7 +63,9 @@ class Phi2(nn.Module):
     )
     self.rope_cache = attn_utils.build_rope_cache(
         size=config.kv_cache_max,
-        dim=int(config.attn_config.rotary_percentage * config.attn_config.head_dim),
+        dim=int(
+            config.attn_config.rotary_percentage * config.attn_config.head_dim
+        ),
         base=10_000,
         condense_ratio=1,
         dtype=torch.float32,

--- a/ai_edge_torch/generative/examples/phi2/phi2.py
+++ b/ai_edge_torch/generative/examples/phi2/phi2.py
@@ -63,7 +63,7 @@ class Phi2(nn.Module):
     )
     self.rope_cache = attn_utils.build_rope_cache(
         size=config.kv_cache_max,
-        dim=int(config.attn_config.rotary_percentage * config.head_dim),
+        dim=int(config.attn_config.rotary_percentage * config.attn_config.head_dim),
         base=10_000,
         condense_ratio=1,
         dtype=torch.float32,
@@ -107,6 +107,7 @@ class Phi2(nn.Module):
 def get_model_config(kv_cache_max_len: int = 1024) -> cfg.ModelConfig:
   attn_config = cfg.AttentionConfig(
       num_heads=32,
+      head_dim=80,
       num_query_groups=32,
       rotary_percentage=0.4,
       qkv_use_bias=True,

--- a/ai_edge_torch/generative/examples/stable_diffusion/clip.py
+++ b/ai_edge_torch/generative/examples/stable_diffusion/clip.py
@@ -92,6 +92,7 @@ def get_model_config() -> cfg.ModelConfig:
 
   attn_config = cfg.AttentionConfig(
       num_heads=num_heads,
+      head_dim=embedding_dim // num_heads,
       num_query_groups=num_query_groups,
       rotary_percentage=0.0,
       qkv_use_bias=True,

--- a/ai_edge_torch/generative/examples/stable_diffusion/decoder.py
+++ b/ai_edge_torch/generative/examples/stable_diffusion/decoder.py
@@ -288,6 +288,7 @@ def get_model_config() -> unet_cfg.AutoEncoderConfig:
       normalization_config=norm_config,
       attention_config=layers_cfg.AttentionConfig(
           num_heads=1,
+          head_dim=block_out_channels[-1],
           num_query_groups=1,
           qkv_use_bias=True,
           output_proj_use_bias=True,

--- a/ai_edge_torch/generative/examples/stable_diffusion/diffusion.py
+++ b/ai_edge_torch/generative/examples/stable_diffusion/diffusion.py
@@ -195,6 +195,31 @@ TENSOR_NAMES = stable_diffusion_loader.DiffusionModelLoader.TensorNames(
 )
 
 
+def build_attention_config(
+    num_heads,
+    dim,
+    num_query_groups,
+    rotary_percentage=0.0,
+    qkv_transpose_before_split=True,
+    qkv_use_bias=False,
+    output_proj_use_bias=True,
+    enable_kv_cache=False,
+    qkv_fused_interleaved=False,
+):
+
+  return layers_cfg.AttentionConfig(
+      num_heads=num_heads,
+      head_dim=dim // num_heads,
+      num_query_groups=num_query_groups,
+      rotary_percentage=rotary_percentage,
+      qkv_transpose_before_split=qkv_transpose_before_split,
+      qkv_use_bias=qkv_use_bias,
+      output_proj_use_bias=output_proj_use_bias,
+      enable_kv_cache=enable_kv_cache,
+      qkv_fused_interleaved=qkv_fused_interleaved,
+  )
+
+
 class TimeEmbedding(nn.Module):
 
   def __init__(self, in_dim, out_dim):
@@ -267,18 +292,6 @@ class Diffusion(nn.Module):
         config.in_channels, block_out_channels[0], kernel_size=3, padding=1
     )
 
-    attention_config = layers_cfg.AttentionConfig(
-        num_heads=config.transformer_num_attention_heads,
-        head_dim=block_out_channels[0] // config.transformer_num_attention_heads,
-        num_query_groups=config.transformer_num_attention_heads,
-        rotary_percentage=0.0,
-        qkv_transpose_before_split=True,
-        qkv_use_bias=False,
-        output_proj_use_bias=True,
-        enable_kv_cache=False,
-        qkv_fused_interleaved=False,
-    )
-
     # Down encoders.
     down_encoders = []
     output_channel = block_out_channels[0]
@@ -313,7 +326,11 @@ class Diffusion(nn.Module):
                             dim=output_channel,
                             attention_batch_size=config.transformer_batch_size,
                             normalization_config=config.transformer_norm_config,
-                            attention_config=attention_config,
+                            attention_config=build_attention_config(
+                                num_heads=config.transformer_num_attention_heads,
+                                dim=output_channel,
+                                num_query_groups=config.transformer_num_attention_heads,
+                            ),
                             enable_hlfb=False,
                         ),
                         cross_attention_block_config=unet_cfg.CrossAttentionBlock2DConfig(
@@ -321,7 +338,11 @@ class Diffusion(nn.Module):
                             cross_dim=config.transformer_cross_attention_dim,
                             attention_batch_size=config.transformer_batch_size,
                             normalization_config=config.transformer_norm_config,
-                            attention_config=attention_config,
+                            attention_config=build_attention_config(
+                                num_heads=config.transformer_num_attention_heads,
+                                dim=output_channel,
+                                num_query_groups=config.transformer_num_attention_heads,
+                            ),
                             enable_hlfb=False,
                         ),
                         pre_conv_normalization_config=config.transformer_pre_conv_norm_config,
@@ -375,7 +396,11 @@ class Diffusion(nn.Module):
                     dim=mid_block_channels,
                     attention_batch_size=config.transformer_batch_size,
                     normalization_config=config.transformer_norm_config,
-                    attention_config=attention_config,
+                    attention_config=build_attention_config(
+                        num_heads=config.transformer_num_attention_heads,
+                        dim=mid_block_channels,
+                        num_query_groups=config.transformer_num_attention_heads,
+                    ),
                     enable_hlfb=False,
                 ),
                 cross_attention_block_config=unet_cfg.CrossAttentionBlock2DConfig(
@@ -383,7 +408,11 @@ class Diffusion(nn.Module):
                     cross_dim=config.transformer_cross_attention_dim,
                     attention_batch_size=config.transformer_batch_size,
                     normalization_config=config.transformer_norm_config,
-                    attention_config=attention_config,
+                    attention_config=build_attention_config(
+                        num_heads=config.transformer_num_attention_heads,
+                        dim=mid_block_channels,
+                        num_query_groups=config.transformer_num_attention_heads,
+                    ),
                     enable_hlfb=False,
                 ),
                 pre_conv_normalization_config=config.transformer_pre_conv_norm_config,
@@ -438,7 +467,11 @@ class Diffusion(nn.Module):
                             dim=output_channel,
                             attention_batch_size=config.transformer_batch_size,
                             normalization_config=config.transformer_norm_config,
-                            attention_config=attention_config,
+                            attention_config=build_attention_config(
+                                num_heads=config.transformer_num_attention_heads,
+                                dim=output_channel,
+                                num_query_groups=config.transformer_num_attention_heads,
+                            ),
                             enable_hlfb=False,
                         ),
                         cross_attention_block_config=unet_cfg.CrossAttentionBlock2DConfig(
@@ -446,7 +479,11 @@ class Diffusion(nn.Module):
                             cross_dim=config.transformer_cross_attention_dim,
                             attention_batch_size=config.transformer_batch_size,
                             normalization_config=config.transformer_norm_config,
-                            attention_config=attention_config,
+                            attention_config=build_attention_config(
+                                num_heads=config.transformer_num_attention_heads,
+                                dim=output_channel,
+                                num_query_groups=config.transformer_num_attention_heads,
+                            ),
                             enable_hlfb=False,
                         ),
                         pre_conv_normalization_config=config.transformer_pre_conv_norm_config,

--- a/ai_edge_torch/generative/examples/stable_diffusion/diffusion.py
+++ b/ai_edge_torch/generative/examples/stable_diffusion/diffusion.py
@@ -269,6 +269,7 @@ class Diffusion(nn.Module):
 
     attention_config = layers_cfg.AttentionConfig(
         num_heads=config.transformer_num_attention_heads,
+        head_dim=block_out_channels[0] // config.transformer_num_attention_heads,
         num_query_groups=config.transformer_num_attention_heads,
         rotary_percentage=0.0,
         qkv_transpose_before_split=True,

--- a/ai_edge_torch/generative/examples/t5/t5.py
+++ b/ai_edge_torch/generative/examples/t5/t5.py
@@ -371,6 +371,7 @@ class T5Decoder(nn.Module):
 def get_model_config_t5() -> cfg.ModelConfig:
   attn_config = cfg.AttentionConfig(
       num_heads=12,
+      head_dim=64,
       num_query_groups=12,
       qkv_use_bias=False,
       relative_attention_num_buckets=32,

--- a/ai_edge_torch/generative/examples/t5/t5_attention.py
+++ b/ai_edge_torch/generative/examples/t5/t5_attention.py
@@ -185,7 +185,7 @@ class T5Attention(CrossAttention):
     )  # batch size, sequence length, embedding dimensionality (n_embd)
     query_states = self.q_projection(x)
     query_states = query_states.reshape(
-        B, T, -1, self.head_dim
+        B, T, -1, self.config.head_dim
     )  # (B, T, nh_q, hs)
 
     if key_value_states is not None:
@@ -198,13 +198,13 @@ class T5Attention(CrossAttention):
       )  # batch size, sequence length, embedding dimensionality (n_embd)
       key_states = self.k_projection(key_value_states)
       value_states = self.v_projection(key_value_states)
-      key_states = key_states.reshape(kvB, kvT, -1, self.head_dim)
-      value_states = value_states.reshape(kvB, kvT, -1, self.head_dim)
+      key_states = key_states.reshape(kvB, kvT, -1, self.config.head_dim)
+      value_states = value_states.reshape(kvB, kvT, -1, self.config.head_dim)
     else:
       key_states = self.k_projection(x)
       value_states = self.v_projection(x)
-      key_states = key_states.reshape(B, T, -1, self.head_dim)
-      value_states = value_states.reshape(B, T, -1, self.head_dim)
+      key_states = key_states.reshape(B, T, -1, self.config.head_dim)
+      value_states = value_states.reshape(B, T, -1, self.config.head_dim)
 
     if key_value_states is None and self.kv_cache is not None:
       key_states, value_states = self.kv_cache.update_cache(
@@ -221,7 +221,7 @@ class T5Attention(CrossAttention):
             0
         )  # shape (1, num_heads, query_length, key_length)
       else:
-        # position_bias = torch.zeros(B, self.n_heads, T, self.head_dim, dtype=torch.float32)
+        # position_bias = torch.zeros(B, self.n_heads, T, self.config.head_dim, dtype=torch.float32)
         position_bias = torch.zeros_like(mask, dtype=torch.float32)
 
     mask = mask + position_bias
@@ -229,7 +229,7 @@ class T5Attention(CrossAttention):
         query_states,
         key_states,
         value_states,
-        self.head_dim,
+        self.config.head_dim,
         mask=mask,
         scale=1.0,
     )

--- a/ai_edge_torch/generative/examples/test_models/toy_model.py
+++ b/ai_edge_torch/generative/examples/test_models/toy_model.py
@@ -43,7 +43,9 @@ class ToySingleLayerModel(torch.nn.Module):
     )
     self.rope_cache = attn_utils.build_rope_cache(
         size=config.max_seq_len,
-        dim=int(config.attn_config.rotary_percentage * config.attn_config.head_dim),
+        dim=int(
+            config.attn_config.rotary_percentage * config.attn_config.head_dim
+        ),
         base=10_000,
         condense_ratio=1,
         dtype=torch.float32,

--- a/ai_edge_torch/generative/examples/test_models/toy_model.py
+++ b/ai_edge_torch/generative/examples/test_models/toy_model.py
@@ -43,7 +43,7 @@ class ToySingleLayerModel(torch.nn.Module):
     )
     self.rope_cache = attn_utils.build_rope_cache(
         size=config.max_seq_len,
-        dim=int(config.attn_config.rotary_percentage * config.head_dim),
+        dim=int(config.attn_config.rotary_percentage * config.attn_config.head_dim),
         base=10_000,
         condense_ratio=1,
         dtype=torch.float32,
@@ -72,6 +72,7 @@ class ToySingleLayerModel(torch.nn.Module):
 def get_model_config() -> cfg.ModelConfig:
   attn_config = cfg.AttentionConfig(
       num_heads=32,
+      head_dim=4,
       num_query_groups=4,
       rotary_percentage=1.0,
       enable_kv_cache=False,

--- a/ai_edge_torch/generative/examples/test_models/toy_model_with_external_kv_cache.py
+++ b/ai_edge_torch/generative/examples/test_models/toy_model_with_external_kv_cache.py
@@ -46,7 +46,9 @@ class ToyModelWithExternalKV(torch.nn.Module):
     )
     self.rope_cache = attn_utils.build_rope_cache(
         size=config.max_seq_len,
-        dim=int(config.attn_config.rotary_percentage * config.attn_config.head_dim),
+        dim=int(
+            config.attn_config.rotary_percentage * config.attn_config.head_dim
+        ),
         base=10_000,
         condense_ratio=1,
         dtype=torch.float32,

--- a/ai_edge_torch/generative/examples/test_models/toy_model_with_external_kv_cache.py
+++ b/ai_edge_torch/generative/examples/test_models/toy_model_with_external_kv_cache.py
@@ -46,7 +46,7 @@ class ToyModelWithExternalKV(torch.nn.Module):
     )
     self.rope_cache = attn_utils.build_rope_cache(
         size=config.max_seq_len,
-        dim=int(config.attn_config.rotary_percentage * config.head_dim),
+        dim=int(config.attn_config.rotary_percentage * config.attn_config.head_dim),
         base=10_000,
         condense_ratio=1,
         dtype=torch.float32,
@@ -90,7 +90,7 @@ def _export_stablehlo_mlir(model, args):
 
 def get_model_config() -> cfg.ModelConfig:
   attn_config = cfg.AttentionConfig(
-      num_heads=32, num_query_groups=4, rotary_percentage=1.0
+      num_heads=32, head_dim=4, num_query_groups=4, rotary_percentage=1.0
   )
   ff_config = cfg.FeedForwardConfig(
       type=cfg.FeedForwardType.GATED,

--- a/ai_edge_torch/generative/examples/test_models/toy_model_with_kv_cache.py
+++ b/ai_edge_torch/generative/examples/test_models/toy_model_with_kv_cache.py
@@ -45,7 +45,9 @@ class ToyModelWithKV(torch.nn.Module):
     )
     self.rope_cache = attn_utils.build_rope_cache(
         size=config.max_seq_len,
-        dim=int(config.attn_config.rotary_percentage * config.attn_config.head_dim),
+        dim=int(
+            config.attn_config.rotary_percentage * config.attn_config.head_dim
+        ),
         base=10_000,
         condense_ratio=1,
         dtype=torch.float32,

--- a/ai_edge_torch/generative/examples/test_models/toy_model_with_kv_cache.py
+++ b/ai_edge_torch/generative/examples/test_models/toy_model_with_kv_cache.py
@@ -45,7 +45,7 @@ class ToyModelWithKV(torch.nn.Module):
     )
     self.rope_cache = attn_utils.build_rope_cache(
         size=config.max_seq_len,
-        dim=int(config.attn_config.rotary_percentage * config.head_dim),
+        dim=int(config.attn_config.rotary_percentage * config.attn_config.head_dim),
         base=10_000,
         condense_ratio=1,
         dtype=torch.float32,
@@ -78,7 +78,7 @@ def _export_stablehlo_mlir(model, args):
 
 def get_model_config() -> cfg.ModelConfig:
   attn_config = cfg.AttentionConfig(
-      num_heads=32, num_query_groups=4, rotary_percentage=1.0
+      num_heads=32, head_dim=4, num_query_groups=4, rotary_percentage=1.0
   )
   ff_config = cfg.FeedForwardConfig(
       type=cfg.FeedForwardType.GATED,

--- a/ai_edge_torch/generative/examples/tiny_llama/tiny_llama.py
+++ b/ai_edge_torch/generative/examples/tiny_llama/tiny_llama.py
@@ -64,7 +64,9 @@ class TinyLLamma(nn.Module):
     )
     self.rope_cache = attn_utils.build_rope_cache(
         size=config.kv_cache_max,
-        dim=int(config.attn_config.rotary_percentage * config.attn_config.head_dim),
+        dim=int(
+            config.attn_config.rotary_percentage * config.attn_config.head_dim
+        ),
         base=10_000,
         condense_ratio=1,
         dtype=torch.float32,

--- a/ai_edge_torch/generative/examples/tiny_llama/tiny_llama.py
+++ b/ai_edge_torch/generative/examples/tiny_llama/tiny_llama.py
@@ -64,7 +64,7 @@ class TinyLLamma(nn.Module):
     )
     self.rope_cache = attn_utils.build_rope_cache(
         size=config.kv_cache_max,
-        dim=int(config.attn_config.rotary_percentage * config.head_dim),
+        dim=int(config.attn_config.rotary_percentage * config.attn_config.head_dim),
         base=10_000,
         condense_ratio=1,
         dtype=torch.float32,
@@ -109,6 +109,7 @@ class TinyLLamma(nn.Module):
 def get_model_config(kv_cache_max_len: int = 1024) -> cfg.ModelConfig:
   attn_config = cfg.AttentionConfig(
       num_heads=32,
+      head_dim=64,
       num_query_groups=4,
       rotary_percentage=1.0,
   )

--- a/ai_edge_torch/generative/fx_passes/test/test_remove_sdpa_zero_mask_pass.py
+++ b/ai_edge_torch/generative/fx_passes/test/test_remove_sdpa_zero_mask_pass.py
@@ -99,6 +99,7 @@ class TestRemoveSDPAZeroMaskPass(unittest.TestCase):
           normalization_config=norm_config,
           attention_config=layers_cfg.AttentionConfig(
               num_heads=1,
+              head_dim=block_out_channels[-1],
               num_query_groups=1,
               qkv_use_bias=True,
               output_proj_use_bias=True,

--- a/ai_edge_torch/generative/layers/attention.py
+++ b/ai_edge_torch/generative/layers/attention.py
@@ -135,16 +135,16 @@ class CausalSelfAttention(nn.Module):
       enable_hlfb (bool): whether hlfb is enabled or not.
     """
     super().__init__()
-    self.head_dim = dim // config.num_heads
-    shape = (config.num_heads + 2 * config.num_query_groups) * self.head_dim
-    # Key, query, value projections for all heads.
-    self.qkv_projection = nn.Linear(dim, shape, bias=config.qkv_use_bias)
-    self.output_projection = nn.Linear(
-        dim, dim, bias=config.output_proj_use_bias
-    )
     self.config = config
     self.kv_cache = None
     self.batch_size = batch_size
+    qkv_shape = (config.num_heads + 2 * config.num_query_groups) * config.head_dim
+    output_shape = config.num_heads * config.head_dim
+    # Key, query, value projections for all heads.
+    self.qkv_projection = nn.Linear(dim, qkv_shape, bias=config.qkv_use_bias)
+    self.output_projection = nn.Linear(
+        output_shape, dim, bias=config.output_proj_use_bias
+    )
 
     # Build a k/v cache with size (batch_size, kv_cache_max, n_heads, head_dim).
     if config.enable_kv_cache:
@@ -152,7 +152,7 @@ class CausalSelfAttention(nn.Module):
           batch_size,
           kv_cache_max,
           config.num_query_groups,
-          self.head_dim,
+          config.head_dim,
           enable_hlfb,
       )
 
@@ -193,7 +193,7 @@ class CausalSelfAttention(nn.Module):
     q_per_kv = self.config.num_heads // self.config.num_query_groups
     # Each group has >=1 queries, 1 key, and 1 value.
     if self.config.qkv_transpose_before_split:
-      qkv = qkv.view(B, T, -1, self.head_dim)
+      qkv = qkv.view(B, T, -1, self.config.head_dim)
       q, k, v = qkv.split(
           (
               q_per_kv * self.config.num_query_groups,
@@ -205,23 +205,24 @@ class CausalSelfAttention(nn.Module):
     else:
       qkv = qkv.view(B, T, self.config.num_query_groups, -1)
       q, k, v = qkv.split(
-          (q_per_kv * self.head_dim, self.head_dim, self.head_dim), dim=-1
+          (q_per_kv * self.config.head_dim, self.config.head_dim, self.config.head_dim),
+          dim=-1,
       )
 
-    q = q.reshape(B, T, -1, self.head_dim)
-    k = k.reshape(B, T, -1, self.head_dim)
-    v = v.reshape(B, T, -1, self.head_dim)
+    q = q.reshape(B, T, -1, self.config.head_dim)
+    k = k.reshape(B, T, -1, self.config.head_dim)
+    v = v.reshape(B, T, -1, self.config.head_dim)
 
     # Compute rotary positional embedding for query and key.
-    n_elem = int(self.config.rotary_percentage * self.head_dim)
+    n_elem = int(self.config.rotary_percentage * self.config.head_dim)
     q, k = _embed_rope(q, k, n_elem, rope)
 
     if self.kv_cache is not None:
       # TODO(haoliang): Handle when execeeding max sequence length.
       k, v = self.kv_cache.update_cache(input_pos, k, v)
 
-    y = self.sdpa_func(q, k, v, self.head_dim, mask=mask)
-    y = y.reshape(B, T, E)
+    y = self.sdpa_func(q, k, v, self.config.head_dim, mask=mask)
+    y = y.reshape(B, T, _)
 
     # Compute the output projection.
     y = self.output_projection(y)

--- a/ai_edge_torch/generative/layers/experimental/ekv_cache.py
+++ b/ai_edge_torch/generative/layers/experimental/ekv_cache.py
@@ -41,7 +41,7 @@ class KVCacheEntry:
         1,
         config.kv_cache_max,
         config.attn_config.num_query_groups,
-        config.head_dim,
+        config.attn_config.head_dim,
     )
     k = torch.zeros(shape, dtype=dtype, device=device)
     v = torch.zeros(shape, dtype=dtype, device=device)

--- a/ai_edge_torch/generative/layers/model_config.py
+++ b/ai_edge_torch/generative/layers/model_config.py
@@ -55,9 +55,10 @@ class FeedForwardType(enum.Enum):
 
 @dataclass
 class AttentionConfig:
-  """Attention moduel's parameters."""
+  """Attention model's parameters."""
 
   num_heads: int
+  head_dim: int
   # Used to determine number of groups in grouped query attention (GQA)
   # https://arxiv.org/pdf/2305.13245.pdf
   num_query_groups: Optional[int]
@@ -156,7 +157,3 @@ class ModelConfig:
       return self.kv_cache_max_len
     else:
       return self.max_seq_len
-
-  @property
-  def head_dim(self) -> int:
-    return self.embedding_dim // self.attn_config.num_heads

--- a/ai_edge_torch/generative/test/test_experimental_ekv.py
+++ b/ai_edge_torch/generative/test/test_experimental_ekv.py
@@ -31,7 +31,7 @@ class TestExternalKVLayers(unittest.TestCase):
       self, num_layers, head_dim, num_query_groups, kv_cache_max_len
   ):
     attn_config = cfg.AttentionConfig(
-        num_heads=1, num_query_groups=num_query_groups
+        num_heads=1, head_dim=head_dim, num_query_groups=num_query_groups
     )
     config = cfg.ModelConfig(
         kv_cache_max_len=kv_cache_max_len,

--- a/ai_edge_torch/generative/utilities/loader.py
+++ b/ai_edge_torch/generative/utilities/loader.py
@@ -346,9 +346,9 @@ class ModelLoader:
       q_per_kv = (
           config.attn_config.num_heads // config.attn_config.num_query_groups
       )
-      qs = torch.split(q, config.head_dim * q_per_kv)
-      ks = torch.split(k, config.head_dim)
-      vs = torch.split(v, config.head_dim)
+      qs = torch.split(q, config.attn_config.head_dim * q_per_kv)
+      ks = torch.split(k, config.attn_config.head_dim)
+      vs = torch.split(v, config.attn_config.head_dim)
       cycled = [t for group in zip(qs, ks, vs) for t in group]
       return torch.cat(cycled)
     else:

--- a/ai_edge_torch/generative/utilities/stable_diffusion_loader.py
+++ b/ai_edge_torch/generative/utilities/stable_diffusion_loader.py
@@ -743,7 +743,10 @@ class DiffusionModelLoader(BaseLoader):
 
     attention_config = layers_config.AttentionConfig(
         num_heads=config.transformer_num_attention_heads,
-        head_dim=config.block_out_channels[0] // config.transformer_num_attention_heads,
+        head_dim=(
+            config.block_out_channels[0]
+            // config.transformer_num_attention_heads
+        ),
         num_query_groups=config.transformer_num_attention_heads,
         rotary_percentage=0.0,
         qkv_transpose_before_split=True,

--- a/ai_edge_torch/generative/utilities/stable_diffusion_loader.py
+++ b/ai_edge_torch/generative/utilities/stable_diffusion_loader.py
@@ -683,6 +683,31 @@ class AutoEncoderModelLoader(BaseLoader):
     return model.load_state_dict(converted_state, strict=strict)
 
 
+def build_attention_config(
+    num_heads,
+    dim,
+    num_query_groups,
+    rotary_percentage=0.0,
+    qkv_transpose_before_split=True,
+    qkv_use_bias=False,
+    output_proj_use_bias=True,
+    enable_kv_cache=False,
+    qkv_fused_interleaved=False,
+):
+
+  return layers_config.AttentionConfig(
+      num_heads=num_heads,
+      head_dim=dim // num_heads,
+      num_query_groups=num_query_groups,
+      rotary_percentage=rotary_percentage,
+      qkv_transpose_before_split=qkv_transpose_before_split,
+      qkv_use_bias=qkv_use_bias,
+      output_proj_use_bias=output_proj_use_bias,
+      enable_kv_cache=enable_kv_cache,
+      qkv_fused_interleaved=qkv_fused_interleaved,
+  )
+
+
 class DiffusionModelLoader(BaseLoader):
 
   @dataclass
@@ -741,20 +766,6 @@ class DiffusionModelLoader(BaseLoader):
         state, self._names.final_norm, converted_state, "final_norm"
     )
 
-    attention_config = layers_config.AttentionConfig(
-        num_heads=config.transformer_num_attention_heads,
-        head_dim=(
-            config.block_out_channels[0]
-            // config.transformer_num_attention_heads
-        ),
-        num_query_groups=config.transformer_num_attention_heads,
-        rotary_percentage=0.0,
-        qkv_transpose_before_split=True,
-        qkv_use_bias=False,
-        output_proj_use_bias=True,
-        enable_kv_cache=False,
-    )
-
     # Map down_encoders.
     output_channel = config.block_out_channels[0]
     for i, block_out_channel in enumerate(config.block_out_channels):
@@ -785,13 +796,21 @@ class DiffusionModelLoader(BaseLoader):
                 attention_block_config=unet_config.AttentionBlock2DConfig(
                     dim=output_channel,
                     normalization_config=config.transformer_norm_config,
-                    attention_config=attention_config,
+                    attention_config=build_attention_config(
+                        num_heads=config.transformer_num_attention_heads,
+                        dim=output_channel,
+                        num_query_groups=config.transformer_num_attention_heads,
+                    ),
                 ),
                 cross_attention_block_config=unet_config.CrossAttentionBlock2DConfig(
                     query_dim=output_channel,
                     cross_dim=config.transformer_cross_attention_dim,
                     normalization_config=config.transformer_norm_config,
-                    attention_config=attention_config,
+                    attention_config=build_attention_config(
+                        num_heads=config.transformer_num_attention_heads,
+                        dim=output_channel,
+                        num_query_groups=config.transformer_num_attention_heads,
+                    ),
                 ),
                 pre_conv_normalization_config=config.transformer_pre_conv_norm_config,
                 feed_forward_block_config=unet_config.FeedForwardBlock2DConfig(
@@ -843,13 +862,21 @@ class DiffusionModelLoader(BaseLoader):
             attention_block_config=unet_config.AttentionBlock2DConfig(
                 dim=mid_block_channels,
                 normalization_config=config.transformer_norm_config,
-                attention_config=attention_config,
+                attention_config=build_attention_config(
+                    num_heads=config.transformer_num_attention_heads,
+                    dim=mid_block_channels,
+                    num_query_groups=config.transformer_num_attention_heads,
+                ),
             ),
             cross_attention_block_config=unet_config.CrossAttentionBlock2DConfig(
                 query_dim=mid_block_channels,
                 cross_dim=config.transformer_cross_attention_dim,
                 normalization_config=config.transformer_norm_config,
-                attention_config=attention_config,
+                attention_config=build_attention_config(
+                    num_heads=config.transformer_num_attention_heads,
+                    dim=mid_block_channels,
+                    num_query_groups=config.transformer_num_attention_heads,
+                ),
             ),
             pre_conv_normalization_config=config.transformer_pre_conv_norm_config,
             feed_forward_block_config=unet_config.FeedForwardBlock2DConfig(
@@ -908,13 +935,21 @@ class DiffusionModelLoader(BaseLoader):
                 attention_block_config=unet_config.AttentionBlock2DConfig(
                     dim=output_channel,
                     normalization_config=config.transformer_norm_config,
-                    attention_config=attention_config,
+                    attention_config=build_attention_config(
+                        num_heads=config.transformer_num_attention_heads,
+                        dim=output_channel,
+                        num_query_groups=config.transformer_num_attention_heads,
+                    ),
                 ),
                 cross_attention_block_config=unet_config.CrossAttentionBlock2DConfig(
                     query_dim=output_channel,
                     cross_dim=config.transformer_cross_attention_dim,
                     normalization_config=config.transformer_norm_config,
-                    attention_config=attention_config,
+                    attention_config=build_attention_config(
+                        num_heads=config.transformer_num_attention_heads,
+                        dim=output_channel,
+                        num_query_groups=config.transformer_num_attention_heads,
+                    ),
                 ),
                 pre_conv_normalization_config=config.transformer_pre_conv_norm_config,
                 feed_forward_block_config=unet_config.FeedForwardBlock2DConfig(

--- a/ai_edge_torch/generative/utilities/stable_diffusion_loader.py
+++ b/ai_edge_torch/generative/utilities/stable_diffusion_loader.py
@@ -743,6 +743,7 @@ class DiffusionModelLoader(BaseLoader):
 
     attention_config = layers_config.AttentionConfig(
         num_heads=config.transformer_num_attention_heads,
+        head_dim=config.block_out_channels[0] // config.transformer_num_attention_heads,
         num_query_groups=config.transformer_num_attention_heads,
         rotary_percentage=0.0,
         qkv_transpose_before_split=True,

--- a/ai_edge_torch/generative/utilities/t5_loader.py
+++ b/ai_edge_torch/generative/utilities/t5_loader.py
@@ -505,8 +505,8 @@ class ModelLoader:
     q_per_kv = (
         config.attn_config.num_heads // config.attn_config.num_query_groups
     )
-    qs = torch.split(q, config.head_dim * q_per_kv)
-    ks = torch.split(k, config.head_dim)
-    vs = torch.split(v, config.head_dim)
+    qs = torch.split(q, config.attn_config.head_dim * q_per_kv)
+    ks = torch.split(k, config.attn_config.head_dim)
+    vs = torch.split(v, config.attn_config.head_dim)
     cycled = [t for group in zip(qs, ks, vs) for t in group]
     return torch.cat(cycled)


### PR DESCRIPTION
Explicitly set head_dim in AttentionConfig

Based on @mbrenon's https://github.com/google-ai-edge/ai-edge-torch/pull/87 this PR adds head_dim configuration for

 - CrossAttention modules
 - T5 AttentionConfigs
 - StableDiffusion

BUG=https://b.corp.google.com/issues/352144652