### PR TITLE
Relax python version requirements.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -79,7 +79,7 @@ setup(
     packages=find_packages(
         include=["ai_edge_torch*"],
     ),
-    python_requires=">=3.9, <3.12",
+    python_requires=">=3.9",
     install_requires=[
         "numpy",
         "scipy",


### PR DESCRIPTION
Considering this project is python only, it doesn't make sense to have strict python version requirements. Note that also pytorch lists the following dependency in their `METADATA` file:

```
Requires-Python: >=3.8.0
```

This becomes an issue since I have a project that defines `python_requires=">=3.9"`, which doesn't match with the current `python_requires=">=3.9, <3.12"`. I can change it to exclude 3.12, but I am actually running 3.12. I can install an older python, but this shouldn't be necessary in the first place.

:warning: Note that this doesn't work because `ai-edge-quantizer-nightly` needs the same modification, however to the best of my knowledge it is not open source.