### PR TITLE
[fix] Fix export to path without directory

### DIFF
--- a/ai_edge_torch/model.py
+++ b/ai_edge_torch/model.py
@@ -155,7 +155,8 @@ class TfLiteModel(Model):
     Args:
       path: The path to file to which the model is serialized.
     """
-    os.makedirs(os.path.dirname(path), exist_ok=True)
+    if os.path.dirname(path) != '':
+      os.makedirs(os.path.dirname(path), exist_ok=True)
     with open(path, 'wb') as file_handle:
       file_handle.write(self._tflite_model)
 

--- a/ai_edge_torch/model.py
+++ b/ai_edge_torch/model.py
@@ -155,7 +155,7 @@ class TfLiteModel(Model):
     Args:
       path: The path to file to which the model is serialized.
     """
-    if os.path.dirname(path) != '':
+    if os.path.dirname(path):
       os.makedirs(os.path.dirname(path), exist_ok=True)
     with open(path, 'wb') as file_handle:
       file_handle.write(self._tflite_model)


### PR DESCRIPTION
`.export("xxx.tflite")` throws an error as it expects the path to contain a directory and creates it (introduced by [this commit](https://github.com/google-ai-edge/ai-edge-torch/commit/c74b0fa3a79469b92fea6c1b45157d7a0d3e8b24)).

Fixed by checking if the path contains a directory, and only creates it if there is.