### PR TITLE
Fix(loader,lora): harden checkpoint loading and fix LoRA.random dtype

### DIFF
--- a/ai_edge_torch/generative/layers/lora.py
+++ b/ai_edge_torch/generative/layers/lora.py
@@ -268,9 +268,7 @@ class LoRA:
       LoRA weights with random values.
     """
     return cls._from_tensor_generator(
-        tensor_generator=lambda shape, dtype: torch.randint(
-            low=0, high=128, size=shape, dtype=dtype
-        ),
+        tensor_generator=lambda shape, dtype: torch.rand(shape, dtype=dtype),
         rank=rank,
         config=config,
         dtype=dtype,


### PR DESCRIPTION
Hi, Team
I have created this PR for some code improvement so I've made below code changes 
1. Loader Security Hardening(`ai_edge_torch/generative/utilities/loader.py`) for precise file detection so changed from `*pt` to `*.pt` pattern for exact matching and CPU only loading added `map_location=torch.device("cpu")` for safer loading and also added security enhancement `weights_only=True` to prevent pickle based attacks

2. LoRA Random Initialization Fix (`ai_edge_torch/generative/layers/lora.py`) changed from `torch.randint` to `torch.rand` for float dtype runtime error prevention which eliminates crashes when LoRA weights are floating point

I would request you to please review this PR, if you've any feedback or suggestion please let me know that will be very helpful. Thank you for your consideration.
